### PR TITLE
Fix menu item sales calculation

### DIFF
--- a/src/app/[subdomain]/admin/dashboard/page.js
+++ b/src/app/[subdomain]/admin/dashboard/page.js
@@ -90,6 +90,7 @@ export default function DashboardPage() {
                             fullName: data.fullName || '',
                             mobileNumber: data.mobileNumber || '',
                             cart: data.cart || [],
+                            items: data.items || [],
                             addressDetails: data.addressDetails || '',
                             area: data.area || '',
                             region: data.region || '',

--- a/src/app/[subdomain]/admin/dashboard/page.js
+++ b/src/app/[subdomain]/admin/dashboard/page.js
@@ -90,7 +90,6 @@ export default function DashboardPage() {
                             fullName: data.fullName || '',
                             mobileNumber: data.mobileNumber || '',
                             cart: data.cart || [],
-                            items: data.items || [],
                             addressDetails: data.addressDetails || '',
                             area: data.area || '',
                             region: data.region || '',

--- a/src/components/MenuItemsDashboard.js
+++ b/src/components/MenuItemsDashboard.js
@@ -1,17 +1,13 @@
 export default function MenuItemsDashboard({ menuItems, orders }) {
     // Calculate sold quantities for each menu item
-    const itemsWithQuantities = menuItems.map(item => {
+    const itemsWithQuantities = menuItems.map((item) => {
       const quantity = orders.reduce((sum, order) => {
-        const orderItems = Array.isArray(order.cart)
-          ? order.cart
-          : Array.isArray(order.items)
-            ? order.items
-            : [];
+        const orderItems = Array.isArray(order.cart) ? order.cart : [];
 
         const matched = orderItems.filter(
           (oi) =>
-            oi.menuItemId === item.id ||
             oi.itemId === item.id ||
+            oi.menuItemId === item.id ||
             oi.id === item.id
         );
 

--- a/src/components/MenuItemsDashboard.js
+++ b/src/components/MenuItemsDashboard.js
@@ -2,7 +2,11 @@ export default function MenuItemsDashboard({ menuItems, orders }) {
     // Calculate sold quantities for each menu item
     const itemsWithQuantities = menuItems.map(item => {
       const quantity = orders.reduce((sum, order) => {
-        const orderItems = Array.isArray(order.cart) ? order.cart : [];
+        const orderItems = Array.isArray(order.cart)
+          ? order.cart
+          : Array.isArray(order.items)
+            ? order.items
+            : [];
 
         const matched = orderItems.filter(
           (oi) =>

--- a/src/components/MenuItemsDashboard.js
+++ b/src/components/MenuItemsDashboard.js
@@ -2,9 +2,23 @@ export default function MenuItemsDashboard({ menuItems, orders }) {
     // Calculate sold quantities for each menu item
     const itemsWithQuantities = menuItems.map(item => {
       const quantity = orders.reduce((sum, order) => {
-        const orderItem = order.items.find(oi => oi.menuItemId === item.id);
-        return sum + (orderItem ? orderItem.quantity : 0);
+        const orderItems = Array.isArray(order.cart) ? order.cart : [];
+
+        const matched = orderItems.filter(
+          (oi) =>
+            oi.menuItemId === item.id ||
+            oi.itemId === item.id ||
+            oi.id === item.id
+        );
+
+        const qty = matched.reduce(
+          (q, oi) => q + (oi.quantity || oi.qty || 0),
+          0
+        );
+
+        return sum + qty;
       }, 0);
+
       return { ...item, quantitySold: quantity };
     });
   


### PR DESCRIPTION
## Summary
- update menu item sales calculation to read from `order.cart` only

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c9cbb78883279f35588b6979f23a