### PR TITLE
Enable drag-and-drop ordering for menu items

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-scroll": "^1.9.3",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "@dnd-kit/core": "^6.0.6",
+    "@dnd-kit/sortable": "^7.0.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/admin/restaurants/[id]/page.js
+++ b/src/app/admin/restaurants/[id]/page.js
@@ -8,10 +8,13 @@ import {
   addDoc,
   doc,
   deleteDoc,
-  updateDoc
+  updateDoc,
+  query,
+  orderBy
 } from 'firebase/firestore';
 import { db } from '@/firebase/firebaseConfig';
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
+import SortableMenuList from '@/components/SortableMenuList';
 
 export default function RestaurantMenuPage() {
   console.log('Component mounted'); // 🔍 Check this shows in your console
@@ -59,11 +62,13 @@ export default function RestaurantMenuPage() {
   };
 
   const fetchMenuItems = async () => {
-    const snap = await getDocs(collection(db, 'restaurants', id, 'menu'));
+    const q = query(collection(db, 'restaurants', id, 'menu'), orderBy('sortOrder'));
+    const snap = await getDocs(q);
 
     const data = await Promise.all(
       snap.docs.map(async (docSnap) => {
         const item = { id: docSnap.id, ...docSnap.data() };
+        item.sortOrder = typeof item.sortOrder === 'number' ? item.sortOrder : 0;
 
         // ✅ Force addons from subcollection only
         const addonsSnap = await getDocs(collection(db, 'restaurants', id, 'menu', docSnap.id, 'addons'));
@@ -73,6 +78,7 @@ export default function RestaurantMenuPage() {
       })
     );
 
+    data.sort((a, b) => a.sortOrder - b.sortOrder);
     setMenuItems(data);
   };
 
@@ -122,7 +128,8 @@ export default function RestaurantMenuPage() {
   imageUrl,
   isCombo: newItem.isCombo || false,
   comboPrice: newItem.comboPrice ? parseFloat(newItem.comboPrice) : null,
-  comboIncludes: newItem.comboIncludes || ''
+  comboIncludes: newItem.comboIncludes || '',
+  sortOrder: menuItems.length
 });
 
     // 2. Add each addon to the subcollection
@@ -151,6 +158,19 @@ export default function RestaurantMenuPage() {
   const deleteMenuItem = async (itemId) => {
     await deleteDoc(doc(db, 'restaurants', id, 'menu', itemId));
     fetchMenuItems();
+  };
+
+  const handleReorder = async (items) => {
+    setMenuItems(items);
+    await Promise.all(
+      items.map((item, index) => {
+        if (item.sortOrder !== index) {
+          item.sortOrder = index;
+          return updateDoc(doc(db, 'restaurants', id, 'menu', item.id), { sortOrder: index });
+        }
+        return null;
+      })
+    );
   };
 
   const handleUpdateItem = async (e) => {
@@ -282,6 +302,24 @@ export default function RestaurantMenuPage() {
                   </div>
                 ))}
               </div>
+            </div>
+          </div>
+
+          {/* Reorder Menu Items */}
+          <div className="bg-white rounded-lg shadow overflow-hidden mt-6">
+            <div className="px-4 py-5 border-b border-gray-200 sm:px-6">
+              <h3 className="text-lg font-medium leading-6 text-gray-900">Reorder Items</h3>
+            </div>
+            <div className="p-4">
+              <SortableMenuList
+                items={menuItems}
+                onReorder={handleReorder}
+                renderItem={(item) => (
+                  <div className="p-2 border rounded bg-gray-50 mb-2 cursor-move">
+                    {item.name}
+                  </div>
+                )}
+              />
             </div>
           </div>
 

--- a/src/components/SortableMenuList.jsx
+++ b/src/components/SortableMenuList.jsx
@@ -1,0 +1,51 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+function SortableItem({ id, children }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+}
+
+export default function SortableMenuList({ items, renderItem, onReorder }) {
+  const [ordered, setOrdered] = useState(items);
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  useEffect(() => {
+    setOrdered(items);
+  }, [items]);
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = ordered.findIndex((i) => i.id === active.id);
+      const newIndex = ordered.findIndex((i) => i.id === over.id);
+      const newOrder = arrayMove(ordered, oldIndex, newIndex);
+      setOrdered(newOrder);
+      onReorder && onReorder(newOrder);
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={ordered.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+        {ordered.map((item) => (
+          <SortableItem key={item.id} id={item.id}>
+            {renderItem(item)}
+          </SortableItem>
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+}


### PR DESCRIPTION
## Summary
- add dnd-kit libraries
- create `SortableMenuList` component
- sync menu sort order with Firestore
- expose drag-and-drop reordering in restaurant admin page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6874008384588327adf1d2c67ebe38b9