### PR TITLE
Add drag handle for menu sorting

### DIFF
--- a/src/app/admin/restaurants/[id]/page.js
+++ b/src/app/admin/restaurants/[id]/page.js
@@ -15,6 +15,7 @@ import {
 import { db } from '@/firebase/firebaseConfig';
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
 import SortableMenuList from '@/components/SortableMenuList';
+import { GripVertical } from 'lucide-react';
 
 export default function RestaurantMenuPage() {
   const { id } = useParams();
@@ -353,8 +354,14 @@ export default function RestaurantMenuPage() {
                   (item) => selectedCategoryId === '' || item.typeId === selectedCategoryId
                 )}
                 onReorder={handleReorder}
-                renderItem={(item) => (
-                  <div className="p-2 border rounded bg-gray-50 mb-2 cursor-move">
+                renderItem={(item, handleProps) => (
+                  <div className="p-2 border rounded bg-gray-50 mb-2 flex items-center">
+                    <span
+                      className="cursor-grab mr-2 text-gray-500"
+                      {...handleProps}
+                    >
+                      <GripVertical size={16} />
+                    </span>
                     {item.name}
                   </div>
                 )}
@@ -586,9 +593,15 @@ export default function RestaurantMenuPage() {
             <SortableMenuList
               items={menuItems.filter(item => selectedCategoryId === '' || item.typeId === selectedCategoryId)}
               onReorder={handleReorder}
-              renderItem={(item) => (
-                <div className="p-4">
-                  <div className="flex gap-4">
+              renderItem={(item, handleProps) => (
+                <div className="p-4 flex">
+                  <div
+                    className="mr-4 flex items-center cursor-grab text-gray-500"
+                    {...handleProps}
+                  >
+                    <GripVertical size={20} />
+                  </div>
+                  <div className="flex gap-4 flex-1">
                     {item.imageUrl && (
                       <div className="flex-shrink-0">
                         <img
@@ -598,7 +611,6 @@ export default function RestaurantMenuPage() {
                           />
                         </div>
                       )}
-
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start justify-between">
                           <h4 className="text-lg font-semibold text-gray-900">{item.name}</h4>

--- a/src/components/SortableMenuList.jsx
+++ b/src/components/SortableMenuList.jsx
@@ -4,16 +4,17 @@ import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from 
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-function SortableItem({ id, children }) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+function SortableItem({ id, render }) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id });
   const style = {
     transform: CSS.Transform.toString(transform),
     transition
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {children}
+    <div ref={setNodeRef} style={style} {...attributes}>
+      {render({ attributes, listeners })}
     </div>
   );
 }
@@ -41,9 +42,11 @@ export default function SortableMenuList({ items, renderItem, onReorder }) {
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={ordered.map((i) => i.id)} strategy={verticalListSortingStrategy}>
         {ordered.map((item) => (
-          <SortableItem key={item.id} id={item.id}>
-            {renderItem(item)}
-          </SortableItem>
+          <SortableItem
+            key={item.id}
+            id={item.id}
+            render={(handleProps) => renderItem(item, handleProps)}
+          />
         ))}
       </SortableContext>
     </DndContext>


### PR DESCRIPTION
## Summary
- limit sortable menu drag area to an explicit handle
- pass drag handle listeners from `SortableMenuList`
- tweak admin menu page UI to include handle icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d35633a248327b9018a5b1f652759