### PR TITLE
Improve menu editing via modals

### DIFF
--- a/src/app/admin/restaurants/[id]/page.js
+++ b/src/app/admin/restaurants/[id]/page.js
@@ -15,6 +15,8 @@ import {
 import { db } from '@/firebase/firebaseConfig';
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
 import SortableMenuList from '@/components/SortableMenuList';
+import AddItemModal from '@/components/AddItemModal';
+import EditItemModal from '@/components/EditItemModal';
 import { GripVertical } from 'lucide-react';
 
 export default function RestaurantMenuPage() {
@@ -25,7 +27,7 @@ export default function RestaurantMenuPage() {
   const [newCategory, setNewCategory] = useState('');
   const [selectedCategoryId, setSelectedCategoryId] = useState('');
   const [editMode, setEditMode] = useState(null);
-  const [isAddingItem, setIsAddingItem] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
   const storage = getStorage();
 
   const [newItem, setNewItem] = useState({
@@ -146,7 +148,7 @@ export default function RestaurantMenuPage() {
       imageUrl: '',
       imageFile: null
     });
-    setIsAddingItem(false);
+    setShowAddModal(false);
     fetchMenuItems();
   };
 
@@ -298,7 +300,7 @@ export default function RestaurantMenuPage() {
               <h3 className="text-lg font-medium leading-6 text-gray-900">Categories</h3>
             </div>
             <div className="p-4">
-              <div className="flex flex-col sm:flex-row gap-2 mb-4">
+              <div className="flex flex-col md:flex-row gap-2 mb-4">
                 <input
                   type="text"
                   value={newCategory}
@@ -330,193 +332,17 @@ export default function RestaurantMenuPage() {
           {/* Add Menu Item Section */}
           <div className="bg-white rounded-lg shadow overflow-hidden">
             <div className="px-4 py-4 border-b border-gray-200 sm:px-6">
-              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+              <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-2">
                 <h3 className="text-lg font-medium leading-6 text-gray-900">Menu Items</h3>
                 <button
-                  onClick={() => setIsAddingItem(!isAddingItem)}
+                  onClick={() => setShowAddModal(true)}
                   className="inline-flex items-center justify-center px-3 py-1 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6]"
                 >
-                  {isAddingItem ? 'Cancel' : 'Add Item'}
+                  Add Item
                 </button>
               </div>
             </div>
-
-            {isAddingItem && (
-              <div className="p-4 space-y-4 border-b border-gray-200">
-                <input
-                  type="file"
-                  accept="image/*"
-                  onChange={(e) => setNewItem({ ...newItem, imageFile: e.target.files[0] })}
-                  className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-[#7b68ee] file:text-white hover:file:bg-[#6a58d6]"
-                />
-
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <div>
-                    <label htmlFor="name" className="block text-sm font-medium text-gray-700">Name</label>
-                    <input
-                      id="name"
-                      type="text"
-                      value={newItem.name}
-                      onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
-                      className="focus:border-[#7b68ee] focus:ring-[#7b68ee] mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                    />
-                  </div>
-
-                  <div>
-                    <label htmlFor="price" className="block text-sm font-medium text-gray-700">Price</label>
-                    <input
-                      id="price"
-                      type="text"
-                      value={newItem.price}
-                      onChange={(e) => setNewItem({ ...newItem, price: e.target.value })}
-                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label htmlFor="category" className="block text-sm font-medium text-gray-700">Category</label>
-                  <select
-                    id="category"
-                    value={newItem.typeId}
-                    onChange={(e) => {
-                      const selected = categories.find(cat => cat.id === e.target.value);
-                      setNewItem({
-                        ...newItem,
-                        typeId: selected?.id || '',
-                        type: selected?.name || ''
-                      });
-                    }}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                  >
-                    <option value="">Select a category</option>
-                    {categories.map(cat => (
-                      <option key={cat.id} value={cat.id}>{cat.name}</option>
-                    ))}
-                  </select>
-                </div>
-
-                <div>
-                  <label htmlFor="description" className="block text-sm font-medium text-gray-700">Description</label>
-                  <textarea
-                    id="description"
-                    rows={3}
-                    value={newItem.description}
-                    onChange={(e) => setNewItem({ ...newItem, description: e.target.value })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Add-ons</label>
-                    <div className="space-y-2">
-                      {newItem.addons.map((addon, index) => (
-                        <div key={index} className="flex gap-2 items-center">
-                          <input
-                            type="text"
-                            placeholder="Add-on name"
-                            value={addon.name}
-                            onChange={(e) => {
-                              const updated = [...newItem.addons];
-                              updated[index].name = e.target.value;
-                              setNewItem({ ...newItem, addons: updated });
-                            }}
-                            className="flex-1 rounded-md border-gray-300 p-2 text-sm text-gray-800"
-                          />
-                          <input
-                            type="number"
-                            placeholder="Price"
-                            value={isNaN(addon.price) ? '' : addon.price}
-                            onChange={(e) => {
-                              const updated = [...newItem.addons];
-                              updated[index].price = parseFloat(e.target.value) || 0;
-                              setNewItem({ ...newItem, addons: updated });
-                            }}
-                            className="w-20 rounded-md border-gray-300 p-2 text-sm text-gray-800"
-                          />
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const updated = newItem.addons.filter((_, i) => i !== index);
-                              setNewItem({ ...newItem, addons: updated });
-                            }}
-                            className="text-red-600 hover:text-red-800 text-sm"
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setNewItem({
-                            ...newItem,
-                            addons: [...newItem.addons, { name: '', price: 0 }]
-                          })
-                        }
-                        className="text-blue-600 hover:text-blue-800 text-sm mt-2"
-                      >
-                        + Add Add-on
-                      </button>
-                    </div>
-                  </div>
-
-                  <div>
-                    <label htmlFor="remove" className="block text-sm font-medium text-gray-700">Removables</label>
-                    <input
-                      id="remove"
-                      type="text"
-                      placeholder="Comma separated"
-                      onChange={(e) => setNewItem({ ...newItem, remove: e.target.value.split(',').map(s => s.trim()) })}
-                      className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                    />
-                  </div>
-                  
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id="isCombo"
-                      checked={newItem.isCombo}
-                      onChange={(e) => setNewItem({ ...newItem, isCombo: e.target.checked })}
-                      className="h-4 w-4 text-[#7b68ee] focus:ring-[#7b68ee] border-gray-300 rounded"
-                    />
-                    <label htmlFor="isCombo" className="block text-sm font-medium text-gray-700">Is this a Combo?</label>
-                  </div>
-
-                  {newItem.isCombo && (
-                    <>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700">Combo Price</label>
-                        <input
-                          type="number"
-                          placeholder='Insert price'
-                          value={newItem.comboPrice}
-                          onChange={(e) => setNewItem({ ...newItem, comboPrice: e.target.value })}
-                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                        />
-                      </div>
-                      <div className="sm:col-span-2">
-                        <label className="block text-sm font-medium text-gray-700">Combo Includes</label>
-                        <textarea
-                          value={newItem.comboIncludes}
-                          onChange={(e) => setNewItem({ ...newItem, comboIncludes: e.target.value })}
-                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                        />
-                      </div>
-                    </>
-                  )}
-                </div>
-
-                <button
-                  onClick={addMenuItem}
-                  className="w-full md:w-auto inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-[#7b68ee] hover:bg-[#6a58d6] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
-                >
-                  Add Menu Item
-                </button>
-              </div>
-            )}
+            {/* Add item modal component handled below */}
 
             {/* Category Filter */}
             <div className="p-4 border-b border-gray-200">
@@ -544,7 +370,7 @@ export default function RestaurantMenuPage() {
               items={menuItems.filter(item => selectedCategoryId === '' || item.typeId === selectedCategoryId)}
               onReorder={handleReorder}
               renderItem={(item, handleProps) => (
-                <div className="p-4 flex flex-col sm:flex-row gap-4">
+                <div className="p-4 flex flex-col md:flex-row gap-4">
                   <div
                     className="flex items-center cursor-grab text-gray-500 sm:self-start"
                     {...handleProps}
@@ -552,19 +378,19 @@ export default function RestaurantMenuPage() {
                     <GripVertical size={20} />
                   </div>
                   
-                  <div className="flex-1 flex flex-col sm:flex-row gap-4">
+                  <div className="flex-1 flex flex-col md:flex-row gap-4">
                     {item.imageUrl && (
                       <div className="flex-shrink-0">
                         <img
                           src={item.imageUrl}
                           alt={item.name}
-                          className="h-20 w-20 rounded-lg object-cover border border-gray-200"
+                          className="h-20 w-20 md:h-24 md:w-24 rounded-lg object-cover border border-gray-200"
                         />
                       </div>
                     )}
                     
                     <div className="flex-1 min-w-0">
-                      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+                      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2">
                         <h4 className="text-base sm:text-lg font-semibold text-gray-900">{item.name}</h4>
                         <span className="text-base sm:text-lg font-medium text-gray-900">${item.price}</span>
                       </div>
@@ -604,7 +430,7 @@ export default function RestaurantMenuPage() {
                     </div>
                   </div>
 
-                  <div className="flex sm:flex-col gap-2 sm:gap-1 justify-end">
+                  <div className="flex gap-2 md:flex-col md:gap-1 justify-end">
                    <button
   onClick={() => startEdit(item)}
   className="inline-flex items-center justify-center px-3 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
@@ -619,198 +445,29 @@ export default function RestaurantMenuPage() {
                     </button>
                   </div>
 
-                  {/* Edit Form */}
-                  {editMode === item.id && (
-                    <form onSubmit={handleUpdateItem} className="mt-4 w-full bg-gray-50 p-4 rounded-lg border border-gray-200 space-y-4">
-                      <input
-                        type="file"
-                        accept="image/*"
-                        onChange={(e) => setEditItem({ ...editItem, imageFile: e.target.files[0] })}
-                        className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-[#7b68ee] file:text-white hover:file:bg-[#6a58d6]"
-                      />
-
-                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        <div>
-                          <label htmlFor="edit-name" className="block text-sm font-medium text-gray-700">Name</label>
-                          <input
-                            id="edit-name"
-                            type="text"
-                            value={editItem.name}
-                            onChange={(e) => setEditItem({ ...editItem, name: e.target.value })}
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                          />
-                        </div>
-
-                        <div>
-                          <label htmlFor="edit-price" className="block text-sm font-medium text-gray-700">Price</label>
-                          <input
-                            id="edit-price"
-                            type="text"
-                            value={editItem.price}
-                            onChange={(e) => setEditItem({ ...editItem, price: e.target.value })}
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                          />
-                        </div>
-                      </div>
-
-                      <div>
-                        <label htmlFor="edit-category" className="block text-sm font-medium text-gray-700">Category</label>
-                        <select
-                          id="edit-category"
-                          value={editItem.typeId}
-                          onChange={(e) => {
-                            const selected = categories.find(cat => cat.id === e.target.value);
-                            setEditItem({
-                              ...editItem,
-                              typeId: selected?.id || '',
-                              type: selected?.name || ''
-                            });
-                          }}
-                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                        >
-                          <option value="">Select a category</option>
-                          {categories.map(cat => (
-                            <option key={cat.id} value={cat.id}>{cat.name}</option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div>
-                        <label htmlFor="edit-description" className="block text-sm font-medium text-gray-700">Description</label>
-                        <textarea
-                          id="edit-description"
-                          rows={3}
-                          value={editItem.description}
-                          onChange={(e) => setEditItem({ ...editItem, description: e.target.value })}
-                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                        />
-                      </div>
-
-                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        <div>
-                          <label htmlFor="edit-addons" className="block text-sm font-medium text-gray-700">Add-ons</label>
-                          <div className="space-y-2">
-                            {editItem.addons.map((addon, index) => (
-                              <div key={index} className="flex gap-2 items-center">
-                                <input
-                                  type="text"
-                                  placeholder="Add-on name"
-                                  value={addon.name}
-                                  onChange={(e) => {
-                                    const updated = [...editItem.addons];
-                                    updated[index].name = e.target.value;
-                                    setEditItem({ ...editItem, addons: updated });
-                                  }}
-                                  className="flex-1 rounded-md border-gray-300 p-2 text-sm text-gray-800"
-                                />
-                                <input
-                                  type="number"
-                                  placeholder="Price"
-                                  value={addon.price}
-                                  onChange={(e) => {
-                                    const updated = [...editItem.addons];
-                                    updated[index].price = parseFloat(e.target.value);
-                                    setEditItem({ ...editItem, addons: updated });
-                                  }}
-                                  className="w-20 rounded-md border-gray-300 p-2 text-sm text-gray-800"
-                                />
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    const updated = editItem.addons.filter((_, i) => i !== index);
-                                    setEditItem({ ...editItem, addons: updated });
-                                  }}
-                                  className="text-red-600 hover:text-red-800 text-sm"
-                                >
-                                  ×
-                                </button>
-                              </div>
-                            ))}
-
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setEditItem({
-                                  ...editItem,
-                                  addons: [...editItem.addons, { name: '', price: 0 }]
-                                })
-                              }
-                              className="text-blue-600 hover:text-blue-800 text-sm mt-2"
-                            >
-                              + Add Add-on
-                            </button>
-                          </div>
-                        </div>
-
-                        <div>
-                          <label htmlFor="edit-remove" className="block text-sm font-medium text-gray-700">Removables</label>
-                          <input
-                            id="edit-remove"
-                            type="text"
-                            value={editItem.remove.join(', ')}
-                            onChange={(e) => setEditItem({ ...editItem, remove: e.target.value.split(',').map(s => s.trim()) })}
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                          />
-                        </div>
-                        
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="checkbox"
-                            id="edit-isCombo"
-                            checked={editItem.isCombo}
-                            onChange={(e) => setEditItem({ ...editItem, isCombo: e.target.checked })}
-                            className="h-4 w-4 text-[#7b68ee] focus:ring-[#7b68ee] border-gray-300 rounded"
-                          />
-                          <label htmlFor="edit-isCombo" className="block text-sm font-medium text-gray-700">Is this a Combo?</label>
-                        </div>
-
-                        {editItem.isCombo && (
-                          <>
-                            <div>
-                              <label className="block text-sm font-medium text-gray-700">Combo Price</label>
-                              <input
-                                type="number"
-                                placeholder='Insert price'
-                                value={editItem.comboPrice}
-                                onChange={(e) => setEditItem({ ...editItem, comboPrice: e.target.value })}
-                                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                              />
-                            </div>
-                            <div className="sm:col-span-2">
-                              <label className="block text-sm font-medium text-gray-700">Combo Includes</label>
-                              <textarea
-                                value={editItem.comboIncludes}
-                                onChange={(e) => setEditItem({ ...editItem, comboIncludes: e.target.value })}
-                                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
-                              />
-                            </div>
-                          </>
-                        )}
-                      </div>
-
-                      <div className="flex flex-col sm:flex-row justify-end gap-2">
-                        <button
-                          type="button"
-                          onClick={() => setEditMode(null)}
-                          className="w-full sm:w-auto inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          type="submit"
-                          className="w-full sm:w-auto inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
-                        >
-                          Save Changes
-                        </button>
-                      </div>
-                    </form>
-                  )}
+                  {/* Edit form handled via modal below */}
                 </div>
               )}
             />
           </div>
         </div>
       </div>
+      <AddItemModal
+        open={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        newItem={newItem}
+        setNewItem={setNewItem}
+        categories={categories}
+        onAdd={addMenuItem}
+      />
+      <EditItemModal
+        open={!!editMode}
+        onClose={() => setEditMode(null)}
+        editItem={editItem}
+        setEditItem={setEditItem}
+        categories={categories}
+        onSave={handleUpdateItem}
+      />
     </div>
   );
 }

--- a/src/components/AddItemModal.jsx
+++ b/src/components/AddItemModal.jsx
@@ -1,0 +1,218 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function AddItemModal({ open, onClose, newItem, setNewItem, categories, onAdd }) {
+  useEffect(() => {
+    if (!open) {
+      setNewItem({
+        name: '',
+        price: '',
+        typeId: '',
+        type: '',
+        description: '',
+        addons: [],
+        remove: [],
+        imageUrl: '',
+        imageFile: null,
+        isCombo: false,
+        comboPrice: '',
+        comboIncludes: ''
+      });
+    }
+  }, [open, setNewItem]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50 p-4 overflow-y-auto">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl p-6 space-y-4">
+        <div className="flex justify-between items-center border-b pb-2">
+          <h2 className="text-lg font-semibold text-gray-800">Add Menu Item</h2>
+          <button onClick={onClose} className="text-gray-600 hover:text-gray-800 text-xl">×</button>
+        </div>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setNewItem({ ...newItem, imageFile: e.target.files[0] })}
+          className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-[#7b68ee] file:text-white hover:file:bg-[#6a58d6]"
+        />
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-gray-700">Name</label>
+            <input
+              id="name"
+              type="text"
+              value={newItem.name}
+              onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+              className="focus:border-[#7b68ee] focus:ring-[#7b68ee] mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="price" className="block text-sm font-medium text-gray-700">Price</label>
+            <input
+              id="price"
+              type="text"
+              value={newItem.price}
+              onChange={(e) => setNewItem({ ...newItem, price: e.target.value })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="category" className="block text-sm font-medium text-gray-700">Category</label>
+          <select
+            id="category"
+            value={newItem.typeId}
+            onChange={(e) => {
+              const selected = categories.find(cat => cat.id === e.target.value);
+              setNewItem({
+                ...newItem,
+                typeId: selected?.id || '',
+                type: selected?.name || ''
+              });
+            }}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+          >
+            <option value="">Select a category</option>
+            {categories.map(cat => (
+              <option key={cat.id} value={cat.id}>{cat.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="description" className="block text-sm font-medium text-gray-700">Description</label>
+          <textarea
+            id="description"
+            rows={3}
+            value={newItem.description}
+            onChange={(e) => setNewItem({ ...newItem, description: e.target.value })}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Add-ons</label>
+            <div className="space-y-2">
+              {newItem.addons.map((addon, index) => (
+                <div key={index} className="flex gap-2 items-center">
+                  <input
+                    type="text"
+                    placeholder="Add-on name"
+                    value={addon.name}
+                    onChange={(e) => {
+                      const updated = [...newItem.addons];
+                      updated[index].name = e.target.value;
+                      setNewItem({ ...newItem, addons: updated });
+                    }}
+                    className="flex-1 rounded-md border-gray-300 p-2 text-sm text-gray-800"
+                  />
+                  <input
+                    type="number"
+                    placeholder="Price"
+                    value={isNaN(addon.price) ? '' : addon.price}
+                    onChange={(e) => {
+                      const updated = [...newItem.addons];
+                      updated[index].price = parseFloat(e.target.value) || 0;
+                      setNewItem({ ...newItem, addons: updated });
+                    }}
+                    className="w-20 md:w-24 rounded-md border-gray-300 p-2 text-sm text-gray-800"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const updated = newItem.addons.filter((_, i) => i !== index);
+                      setNewItem({ ...newItem, addons: updated });
+                    }}
+                    className="text-red-600 hover:text-red-800 text-sm"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+
+              <button
+                type="button"
+                onClick={() =>
+                  setNewItem({
+                    ...newItem,
+                    addons: [...newItem.addons, { name: '', price: 0 }]
+                  })
+                }
+                className="text-blue-600 hover:text-blue-800 text-sm mt-2"
+              >
+                + Add Add-on
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="remove" className="block text-sm font-medium text-gray-700">Removables</label>
+            <input
+              id="remove"
+              type="text"
+              placeholder="Comma separated"
+              onChange={(e) => setNewItem({ ...newItem, remove: e.target.value.split(',').map(s => s.trim()) })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="isCombo"
+              checked={newItem.isCombo}
+              onChange={(e) => setNewItem({ ...newItem, isCombo: e.target.checked })}
+              className="h-4 w-4 text-[#7b68ee] focus:ring-[#7b68ee] border-gray-300 rounded"
+            />
+            <label htmlFor="isCombo" className="block text-sm font-medium text-gray-700">Is this a Combo?</label>
+          </div>
+
+          {newItem.isCombo && (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Combo Price</label>
+                <input
+                  type="number"
+                  placeholder="Insert price"
+                  value={newItem.comboPrice}
+                  onChange={(e) => setNewItem({ ...newItem, comboPrice: e.target.value })}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-gray-700">Combo Includes</label>
+                <textarea
+                  value={newItem.comboIncludes}
+                  onChange={(e) => setNewItem({ ...newItem, comboIncludes: e.target.value })}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2 border-t">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm bg-white text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onAdd}
+            className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6]"
+          >
+            Add Menu Item
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditItemModal.jsx
+++ b/src/components/EditItemModal.jsx
@@ -1,0 +1,198 @@
+'use client';
+import { Fragment } from 'react';
+
+export default function EditItemModal({ open, onClose, editItem, setEditItem, categories, onSave }) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50 p-4 overflow-y-auto">
+      <form onSubmit={onSave} className="bg-white rounded-lg shadow-xl w-full max-w-2xl p-6 space-y-4">
+        <div className="flex justify-between items-center border-b pb-2">
+          <h2 className="text-lg font-semibold text-gray-800">Edit Item</h2>
+          <button type="button" onClick={onClose} className="text-gray-600 hover:text-gray-800 text-xl">×</button>
+        </div>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setEditItem({ ...editItem, imageFile: e.target.files[0] })}
+          className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-[#7b68ee] file:text-white hover:file:bg-[#6a58d6]"
+        />
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="edit-name" className="block text-sm font-medium text-gray-700">Name</label>
+            <input
+              id="edit-name"
+              type="text"
+              value={editItem.name}
+              onChange={(e) => setEditItem({ ...editItem, name: e.target.value })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="edit-price" className="block text-sm font-medium text-gray-700">Price</label>
+            <input
+              id="edit-price"
+              type="text"
+              value={editItem.price}
+              onChange={(e) => setEditItem({ ...editItem, price: e.target.value })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="edit-category" className="block text-sm font-medium text-gray-700">Category</label>
+          <select
+            id="edit-category"
+            value={editItem.typeId}
+            onChange={(e) => {
+              const selected = categories.find(cat => cat.id === e.target.value);
+              setEditItem({
+                ...editItem,
+                typeId: selected?.id || '',
+                type: selected?.name || ''
+              });
+            }}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+          >
+            <option value="">Select a category</option>
+            {categories.map(cat => (
+              <option key={cat.id} value={cat.id}>{cat.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="edit-description" className="block text-sm font-medium text-gray-700">Description</label>
+          <textarea
+            id="edit-description"
+            rows={3}
+            value={editItem.description}
+            onChange={(e) => setEditItem({ ...editItem, description: e.target.value })}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="edit-addons" className="block text-sm font-medium text-gray-700">Add-ons</label>
+            <div className="space-y-2">
+              {editItem.addons.map((addon, index) => (
+                <div key={index} className="flex gap-2 items-center">
+                  <input
+                    type="text"
+                    placeholder="Add-on name"
+                    value={addon.name}
+                    onChange={(e) => {
+                      const updated = [...editItem.addons];
+                      updated[index].name = e.target.value;
+                      setEditItem({ ...editItem, addons: updated });
+                    }}
+                    className="flex-1 rounded-md border-gray-300 p-2 text-sm text-gray-800"
+                  />
+                  <input
+                    type="number"
+                    placeholder="Price"
+                    value={addon.price}
+                    onChange={(e) => {
+                      const updated = [...editItem.addons];
+                      updated[index].price = parseFloat(e.target.value);
+                      setEditItem({ ...editItem, addons: updated });
+                    }}
+                    className="w-20 md:w-24 rounded-md border-gray-300 p-2 text-sm text-gray-800"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const updated = editItem.addons.filter((_, i) => i !== index);
+                      setEditItem({ ...editItem, addons: updated });
+                    }}
+                    className="text-red-600 hover:text-red-800 text-sm"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+
+              <button
+                type="button"
+                onClick={() =>
+                  setEditItem({
+                    ...editItem,
+                    addons: [...editItem.addons, { name: '', price: 0 }]
+                  })
+                }
+                className="text-blue-600 hover:text-blue-800 text-sm mt-2"
+              >
+                + Add Add-on
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="edit-remove" className="block text-sm font-medium text-gray-700">Removables</label>
+            <input
+              id="edit-remove"
+              type="text"
+              value={editItem.remove.join(', ')}
+              onChange={(e) => setEditItem({ ...editItem, remove: e.target.value.split(',').map(s => s.trim()) })}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="edit-isCombo"
+              checked={editItem.isCombo}
+              onChange={(e) => setEditItem({ ...editItem, isCombo: e.target.checked })}
+              className="h-4 w-4 text-[#7b68ee] focus:ring-[#7b68ee] border-gray-300 rounded"
+            />
+            <label htmlFor="edit-isCombo" className="block text-sm font-medium text-gray-700">Is this a Combo?</label>
+          </div>
+
+          {editItem.isCombo && (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Combo Price</label>
+                <input
+                  type="number"
+                  placeholder="Insert price"
+                  value={editItem.comboPrice}
+                  onChange={(e) => setEditItem({ ...editItem, comboPrice: e.target.value })}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-gray-700">Combo Includes</label>
+                <textarea
+                  value={editItem.comboIncludes}
+                  onChange={(e) => setEditItem({ ...editItem, comboIncludes: e.target.value })}
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="flex flex-col md:flex-row justify-end gap-2 pt-2 border-t">
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full md:w-auto inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="w-full md:w-auto inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
+          >
+            Save Changes
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor add/edit menu item forms into separate modal components
- open forms in modals instead of inline blocks
- keep layout responsive using existing utility classes

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d42c53bb88327bc7fb38e6b48c3d4