### PR TITLE
Add custom instructions to cart items

### DIFF
--- a/src/app/[subdomain]/RestaurantPage.js
+++ b/src/app/[subdomain]/RestaurantPage.js
@@ -22,6 +22,7 @@ export default function RestaurantPage({ subdomain }) {
   const [selectedItem, setSelectedItem] = useState(null);
   const [selectedAddons, setSelectedAddons] = useState([]);
   const [selectedRemovables, setSelectedRemovables] = useState([]);
+  const [instructions, setInstructions] = useState('');
   const [isVisible, setIsVisible] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const [isComboSelected, setIsComboSelected] = useState(false);
@@ -178,7 +179,8 @@ if (restaurantData.isActive === false) {
     selectedAddons = [],
     selectedRemovables = [],
     quantity = 1,
-    isComboSelected = false
+    isComboSelected = false,
+    customInstructions = ''
   ) => {
     if (!isRestaurantOpen(restaurant?.openingHours)) {
       alert('The restaurant is currently closed.');
@@ -216,6 +218,7 @@ if (restaurantData.isActive === false) {
       finalTotal,
       selectedAddons,
       selectedRemovables,
+      instructions: customInstructions,
       quantity,
       customKey: `${item.id}-${Date.now()}`
     };
@@ -227,6 +230,7 @@ if (restaurantData.isActive === false) {
     setQuantity(1);
     setSelectedAddons([]);
     setSelectedRemovables([]);
+    setInstructions('');
     setIsComboSelected(false);
   };
 
@@ -434,7 +438,10 @@ if (restaurantData.isActive === false) {
               } pointer-events-auto`}
             onClick={() => {
               setIsVisible(false);
-              setTimeout(() => setSelectedItem(null), 300);
+              setTimeout(() => {
+                setSelectedItem(null);
+                setInstructions('');
+              }, 300);
             }}
           />
 
@@ -450,7 +457,10 @@ if (restaurantData.isActive === false) {
                 <button
                   onClick={() => {
                     setIsVisible(false);
-                    setTimeout(() => setSelectedItem(null), 300);
+                    setTimeout(() => {
+                      setSelectedItem(null);
+                      setInstructions('');
+                    }, 300);
                   }}
                   className="text-gray-500 hover:text-gray-700"
                 >
@@ -550,6 +560,18 @@ if (restaurantData.isActive === false) {
                   </div>
                 </div>
               )}
+
+              {/* Instructions */}
+              <div className="mb-6">
+                <h4 className="font-medium text-gray-800 mb-3">Instructions</h4>
+                <textarea
+                  className="w-full border-gray-300 rounded-md p-2 text-sm text-gray-800 focus:ring-orange-600 focus:border-orange-600"
+                  rows={3}
+                  placeholder="Add any special requests"
+                  value={instructions}
+                  onChange={(e) => setInstructions(e.target.value)}
+                />
+              </div>
             </div>
 
 
@@ -594,7 +616,8 @@ if (restaurantData.isActive === false) {
                       selectedAddons,
                       selectedRemovables,
                       quantity,
-                      isComboSelected
+                      isComboSelected,
+                      instructions
                     );
                   }}
                   className="hover:brightness-120 text-white py-2 px-6 rounded-lg font-medium transition-colors" style={{
@@ -674,6 +697,12 @@ if (restaurantData.isActive === false) {
                             {item.selectedRemovables.map(removable => (
                               <div key={removable}>- {removable}</div>
                             ))}
+                          </div>
+                        )}
+
+                        {item.instructions && (
+                          <div className="mt-1 text-sm text-gray-600">
+                            <div>Note: {item.instructions}</div>
                           </div>
                         )}
                       </div>
@@ -895,7 +924,8 @@ if (restaurantData.isActive === false) {
                         const line = `${i + 1}. ${item.name} x${item.quantity} - $${item.finalTotal.toFixed(2)}`;
                         const addons = item.selectedAddons?.map(a => `   + ${a.name}`).join('\n') || '';
                         const removables = item.selectedRemovables?.map(r => `   - ${r}`).join('\n') || '';
-                        return [line, addons, removables].filter(Boolean).join('\n');
+                        const note = item.instructions ? `   *Note:* ${item.instructions}` : '';
+                        return [line, addons, removables, note].filter(Boolean).join('\n');
                       }),
                       '',
                       `Total: $${orderData.total.toFixed(2)}`

--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -41,7 +41,8 @@ export default function OrderModal({
                     addonsTotal: Number(item.addonsTotal) || 0,
                     quantity: Number(item.quantity) || 1,
                     selectedAddons: Array.isArray(item.selectedAddons) ? item.selectedAddons : [],
-                    selectedRemovables: Array.isArray(item.selectedRemovables) ? item.selectedRemovables : []
+                    selectedRemovables: Array.isArray(item.selectedRemovables) ? item.selectedRemovables : [],
+                    instructions: item.instructions || ''
                 })),
                 addressDetails: originalOrder.addressDetails || '',
                 area: originalOrder.area || '',
@@ -489,6 +490,25 @@ export default function OrderModal({
                                                                     )}
                                                                 </div>
                                                             ))}
+                                                        </div>
+                                                    )}
+
+                                                    {/* Instructions */}
+                                                    {mode === 'view' ? (
+                                                        item.instructions && (
+                                                            <div className="mt-2 text-xs text-gray-600">
+                                                                Note: {item.instructions}
+                                                            </div>
+                                                        )
+                                                    ) : (
+                                                        <div className="mt-2">
+                                                            <textarea
+                                                                value={item.instructions}
+                                                                onChange={(e) => handleItemChange(itemIndex, 'instructions', e.target.value)}
+                                                                className="w-full p-1 border border-gray-300 rounded-md text-xs focus:ring-blue-500 focus:border-blue-500"
+                                                                rows={2}
+                                                                placeholder="Special instructions"
+                                                            />
                                                         </div>
                                                     )}
 


### PR DESCRIPTION
## Summary
- allow guests to add custom instructions when customizing an item
- persist instructions on cart items and orders
- display instructions in carts and in order management
- include instructions when sending the WhatsApp order message

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688539ec4e2c8327a111b4542e295ec1