### PR TITLE
Add order note visibility in admin

### DIFF
--- a/src/app/[subdomain]/admin/dashboard/page.js
+++ b/src/app/[subdomain]/admin/dashboard/page.js
@@ -106,6 +106,7 @@ export default function DashboardPage() {
                             area: data.area || '',
                             region: data.region || '',
                             branchId: data.branchId || '',
+                            orderNote: data.orderNote || '',
                             finalTotal: amount,
                             totalAmount: amount,
                             total: amount,

--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -313,6 +313,28 @@ export default function OrderModal({
                         </div>
                     </div>
 
+                    {/* Order Note */}
+                    <div className="mb-8 bg-gray-50 p-6 rounded-lg border border-gray-100">
+                        <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+                            <svg className="w-5 h-5 mr-2 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 20h9" />
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16.5 3a2.121 2.121 0 113 3L7 18l-4 1 1-4 12.5-12.5z" />
+                            </svg>
+                            Order Note
+                        </h3>
+                        {mode === 'view' ? (
+                            <p className="text-gray-900 bg-white p-2 rounded border border-transparent min-h-[60px]">{formData.orderNote || 'N/A'}</p>
+                        ) : (
+                            <textarea
+                                name="orderNote"
+                                value={formData.orderNote}
+                                onChange={handleChange}
+                                rows={3}
+                                className="text-black w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 transition cursor-text font-medium"
+                            />
+                        )}
+                    </div>
+
                     {/* Order Items Section */}
                     <div className="mb-8">
                         <div className="flex justify-between items-center mb-4">


### PR DESCRIPTION
## Summary
- include `orderNote` when fetching orders in admin dashboard
- display the overall order note in the order modal

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68854089f3a883279d5be0b9b5871ab4