### PR TITLE
Add order tracking page

### DIFF
--- a/src/app/[subdomain]/RestaurantPage.js
+++ b/src/app/[subdomain]/RestaurantPage.js
@@ -966,6 +966,7 @@ const filteredMenuItems = searchTerm
                   try {
                     const finalOrderData = { ...orderData, orderNote };
                     const orderRef = await createOrder(finalOrderData);
+                    const trackUrl = `${window.location.origin}/${subdomain}/order/${orderRef.id}`;
 
                     // Clear cart locally + remotely
                     setCart([]);
@@ -997,6 +998,8 @@ const filteredMenuItems = searchTerm
                         const note = item.instructions ? `   *Note:* ${item.instructions}` : '';
                         return [line, addons, removables, note].filter(Boolean).join('\n');
                       }),
+                      '',
+                      `Track: ${trackUrl}`,
                       '',
                       `Total: $${finalOrderData.total.toFixed(2)}`
                     ];

--- a/src/app/[subdomain]/order/[id]/page.js
+++ b/src/app/[subdomain]/order/[id]/page.js
@@ -1,0 +1,56 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/firebase/firebaseConfig';
+
+export default function TrackOrderPage({ params }) {
+  const { subdomain, id } = params;
+  const [order, setOrder] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchOrder = async () => {
+      try {
+        const snap = await getDoc(doc(db, 'orders', id));
+        if (snap.exists()) {
+          setOrder({ id: snap.id, ...snap.data() });
+        }
+      } catch (err) {
+        console.error('Failed to fetch order', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchOrder();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-purple-500" />
+      </div>
+    );
+  }
+
+  if (!order) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-gray-700">Order not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Order #{order.id.slice(0,6)}</h1>
+      <p className="mb-2"><span className="font-semibold">Status:</span> {order.status}</p>
+      <h2 className="text-xl font-semibold mt-4 mb-2">Items</h2>
+      <ul className="list-disc ml-6">
+        {order.items?.map((item, idx) => (
+          <li key={idx}>{item.name} x{item.quantity}</li>
+        ))}
+      </ul>
+      <p className="mt-4 font-bold">Total: ${order.finalTotal?.toFixed(2)}</p>
+    </div>
+  );
+}

--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -23,6 +23,25 @@ export default function OrderModal({
     const [newAddon, setNewAddon] = useState({ name: '', price: 0 });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const modalRef = useRef();
+    const handleShare = () => {
+        if (!formData?.id) return;
+        let sub;
+        if (typeof window !== 'undefined') {
+            if (window.location.hostname.includes('localhost')) {
+                const parts = window.location.pathname.split('/');
+                sub = parts[1];
+            } else {
+                sub = window.location.hostname.split('.')[0];
+            }
+        }
+        const url = `${window.location.origin}/${sub}/order/${formData.id}`;
+        if (navigator.share) {
+            navigator.share({ url }).catch(console.error);
+        } else if (navigator.clipboard) {
+            navigator.clipboard.writeText(url);
+            alert('Link copied to clipboard');
+        }
+    };
 
     // Close modal when clicking outside
     useEffect(() => {
@@ -216,6 +235,18 @@ export default function OrderModal({
                         </h2>
                         <p className="text-sm text-gray-500 mt-1">Order ID: {formData.id}</p>
                     </div>
+                    {mode === 'view' && (
+                        <button
+                            onClick={handleShare}
+                            className="text-gray-500 hover:text-gray-700 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer mr-2"
+                            aria-label="Share order"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 8a3 3 0 11-6 0 3 3 0 016 0zM19 9v6a2 2 0 01-2 2H7a2 2 0 01-2-2V9" />
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 15l5 5 5-5" />
+                            </svg>
+                        </button>
+                    )}
                     <button
                         onClick={onClose}
                         className="text-gray-500 hover:text-gray-700 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer"


### PR DESCRIPTION
## Summary
- let customers track orders at `/[subdomain]/order/[id]`
- append the tracking link to Whatsapp messages when placing an order
- allow admins to share tracking link from the order modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885658dfaf88327b0c14fe44edc7aad