### PR TITLE
Add order tracking page

### DIFF
--- a/src/app/[subdomain]/RestaurantPage.js
+++ b/src/app/[subdomain]/RestaurantPage.js
@@ -966,6 +966,14 @@ const filteredMenuItems = searchTerm
                   try {
                     const finalOrderData = { ...orderData, orderNote };
                     const orderRef = await createOrder(finalOrderData);
+                    let trackUrl = '';
+                    if (typeof window !== 'undefined') {
+                      if (window.location.hostname.includes('localhost')) {
+                        trackUrl = `${window.location.origin}/${subdomain}/track/${orderRef.id}`;
+                      } else {
+                        trackUrl = `${window.location.origin}/track/${orderRef.id}`;
+                      }
+                    }
 
                     // Clear cart locally + remotely
                     setCart([]);
@@ -988,6 +996,7 @@ const filteredMenuItems = searchTerm
                       `Region: ${finalOrderData.region}, Area: ${finalOrderData.area}`,
                       `Address: ${finalOrderData.addressDetails}`,
                       `Location: ${finalOrderData.mapUrl}`,
+                      `Track Order: ${trackUrl}`,
                       finalOrderData.orderNote ? `Order Note: ${finalOrderData.orderNote}` : '',
                       '',
                       ...finalOrderData.items.map((item, i) => {

--- a/src/app/[subdomain]/track/[orderId]/page.js
+++ b/src/app/[subdomain]/track/[orderId]/page.js
@@ -1,0 +1,47 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { doc, getDoc } from 'firebase/firestore';
+import OrderModal from '@/components/OrderModal';
+import { db } from '@/firebase/firebaseConfig';
+
+export default function TrackOrderPage({ params }) {
+  const { orderId } = params;
+  const router = useRouter();
+  const [order, setOrder] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchOrder = async () => {
+      try {
+        const snap = await getDoc(doc(db, 'orders', orderId));
+        if (snap.exists()) {
+          const data = snap.data();
+          setOrder({
+            id: snap.id,
+            ...data,
+            createdAt: data.createdAt?.toDate() || new Date(),
+            updatedAt: data.updatedAt?.toDate() || new Date(),
+          });
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchOrder();
+  }, [orderId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-indigo-500" />
+      </div>
+    );
+  }
+
+  if (!order) {
+    return <div className="flex justify-center items-center h-screen">Order not found</div>;
+  }
+
+  return <OrderModal order={order} mode="view" onClose={() => router.back()} />;
+}

--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -23,6 +23,28 @@ export default function OrderModal({
     const [newAddon, setNewAddon] = useState({ name: '', price: 0 });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const modalRef = useRef();
+    const generateTrackLink = (id) => {
+        if (typeof window === 'undefined') return '';
+        if (window.location.hostname.includes('localhost')) {
+            const sub = window.location.pathname.split('/')[1];
+            return `${window.location.origin}/${sub}/track/${id}`;
+        }
+        return `${window.location.origin}/track/${id}`;
+    };
+
+    const handleShare = async () => {
+        const link = generateTrackLink(formData.id);
+        try {
+            if (navigator.share) {
+                await navigator.share({ url: link });
+            } else {
+                await navigator.clipboard.writeText(link);
+                alert('Link copied to clipboard');
+            }
+        } catch (err) {
+            console.error('Share failed', err);
+        }
+    };
 
     // Close modal when clicking outside
     useEffect(() => {
@@ -216,15 +238,24 @@ export default function OrderModal({
                         </h2>
                         <p className="text-sm text-gray-500 mt-1">Order ID: {formData.id}</p>
                     </div>
-                    <button
-                        onClick={onClose}
-                        className="text-gray-500 hover:text-gray-700 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer"
-                        aria-label="Close modal"
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                    </button>
+                    <div className="flex items-center space-x-2">
+                        {mode === 'view' && (
+                            <button onClick={handleShare} className="text-blue-600 hover:text-blue-800 p-2 rounded-full hover:bg-blue-50 transition-colors" aria-label="Share order">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 8a3 3 0 11-6 0 3 3 0 016 0zM19.5 21a3.5 3.5 0 00-7 0h7zM12 15v-3m0 0l-3 3m3-3l3 3" />
+                                </svg>
+                            </button>
+                        )}
+                        <button
+                            onClick={onClose}
+                            className="text-gray-500 hover:text-gray-700 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer"
+                            aria-label="Close modal"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
 
                 <form onSubmit={handleSubmit} className="p-6">


### PR DESCRIPTION
## Summary
- add `/track/[orderId]` route for customers to view their order status
- include tracking link in WhatsApp message when placing an order
- allow admins to share the same tracking link from the order modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68856ba0a76c832787094d44a560457b