### PR TITLE
Enable realtime updates on restaurant dashboard

### DIFF
--- a/src/app/[subdomain]/track/[orderId]/page.js
+++ b/src/app/[subdomain]/track/[orderId]/page.js
@@ -1,34 +1,34 @@
 'use client';
 import { use, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, onSnapshot } from 'firebase/firestore';
 import OrderModal from '@/components/OrderModal';
 import { db } from '@/firebase/firebaseConfig';
 
 export default function TrackOrderPage({ params }) {
   const { orderId } = use(params);
-  const router = useRouter();
   const [order, setOrder] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const fetchOrder = async () => {
-      try {
-        const snap = await getDoc(doc(db, 'orders', orderId));
-        if (snap.exists()) {
-          const data = snap.data();
-          setOrder({
-            id: snap.id,
-            ...data,
-            createdAt: data.createdAt?.toDate() || new Date(),
-            updatedAt: data.updatedAt?.toDate() || new Date(),
-          });
-        }
-      } finally {
-        setLoading(false);
+    const ref = doc(db, 'orders', orderId);
+    const unsub = onSnapshot(ref, snap => {
+      if (snap.exists()) {
+        const data = snap.data();
+        setOrder({
+          id: snap.id,
+          ...data,
+          createdAt: data.createdAt?.toDate() || new Date(),
+          updatedAt: data.updatedAt?.toDate() || new Date(),
+        });
+      } else {
+        setOrder(null);
       }
-    };
-    fetchOrder();
+      setLoading(false);
+    }, err => {
+      console.error('Error loading order:', err);
+      setLoading(false);
+    });
+    return () => unsub();
   }, [orderId]);
 
   if (loading) {


### PR DESCRIPTION
## Summary
- add `useRef` and `onSnapshot` in restaurant dashboard
- subscribe to restaurant, orders, and menu collections for realtime updates
- clean up listeners on unmount
- track order page uses `onSnapshot` for live status

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a9f39a684832791ec69220e57389c