### PR TITLE
Fix menu item revenue update after order edits

### DIFF
--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -195,10 +195,19 @@ export default function OrderModal({
         e.preventDefault();
         setIsSubmitting(true);
         try {
+            const itemsWithTotals = formData.cart.map(item => ({
+                ...item,
+                finalTotal: ((item.basePrice || 0) + (item.addonsTotal || 0)) *
+                    (item.quantity || 1)
+            }));
+
             const orderToSave = {
                 ...formData,
-                items: formData.cart,
-                finalTotal: calculateOrderTotal()
+                items: itemsWithTotals,
+                finalTotal: itemsWithTotals.reduce(
+                    (sum, i) => sum + (i.finalTotal || 0),
+                    0
+                )
             };
             delete orderToSave.cart;
             await onSave(orderToSave.id, orderToSave);


### PR DESCRIPTION
## Summary
- ensure each order item's `finalTotal` recomputes when editing an order

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bca297f9c8327a5a1756ffa237760