### PR TITLE
Fix reorder when cart completed

### DIFF
--- a/src/app/[subdomain]/RestaurantPage.js
+++ b/src/app/[subdomain]/RestaurantPage.js
@@ -116,7 +116,16 @@ export default function RestaurantPage({ subdomain }) {
         setBranches(processedBranches);
 
         if (incomingCartId) {
-          setCartId(incomingCartId);
+          try {
+            const existingCart = await getCart(incomingCartId);
+            if (existingCart.status === 'completed') {
+              router.replace('/');
+            } else {
+              setCartId(incomingCartId);
+            }
+          } catch (err) {
+            console.error('Failed to fetch cart', err);
+          }
         }
       } catch (error) {
         console.error('Error:', error);


### PR DESCRIPTION
## Summary
- check cart status on page load
- redirect to normal restaurant page if cart is already completed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bd4d86ae08327a9f18b0e7b077780