### PR TITLE
Add restaurant hours enforcement

### DIFF
--- a/src/app/[subdomain]/RestaurantPage.js
+++ b/src/app/[subdomain]/RestaurantPage.js
@@ -10,6 +10,7 @@ import RestaurantFooter from '@/components/RestaurantFooter';
 import { getCart, addItemToCart, createCart, subscribeToCart, updateCartItemQuantity, removeItemFromCart } from '@/utils/cartService';
 import { createOrder, clearCart } from '@/utils/orderService';
 import { isRestaurantOpen } from '@/utils/openingHours';
+import { toast } from 'react-hot-toast';
 import { useSearchParams, useRouter } from 'next/navigation';
 
 export default function RestaurantPage({ subdomain }) {
@@ -41,6 +42,7 @@ export default function RestaurantPage({ subdomain }) {
   const [isSearching, setIsSearching] = useState(false);
   const [showToast, setShowToast] = useState(false);
   const router = useRouter();
+  const isOpen = isRestaurantOpen(restaurant?.hours);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -196,8 +198,8 @@ export default function RestaurantPage({ subdomain }) {
     isComboSelected = false,
     customInstructions = ''
   ) => {
-    if (!isRestaurantOpen(restaurant?.openingHours)) {
-      alert('The restaurant is currently closed.');
+    if (!isRestaurantOpen(restaurant?.hours)) {
+      toast.error("We're currently closed.");
       return;
     }
     if (cartStatus === 'completed') return; // 🔒 Guard
@@ -386,8 +388,11 @@ export default function RestaurantPage({ subdomain }) {
         </div>
       </header>
 
-
-
+      {!isOpen && (
+        <div className="bg-red-500 text-white text-center py-2">
+          We&apos;re currently closed.
+        </div>
+      )}
 
       {/* Search Bar */}
       <div className="sticky top-0 z-20 bg-white px-4 py-3 shadow-sm">
@@ -501,7 +506,7 @@ export default function RestaurantPage({ subdomain }) {
       </main>
 
       <RestaurantFooter
-        openingHours={restaurant.openingHours}
+        hours={restaurant.hours}
         instagramURL={restaurant.instagramURL}
         tiktokURL={restaurant.tiktokURL}
         facebookURL={restaurant.facebookURL}
@@ -691,6 +696,7 @@ export default function RestaurantPage({ subdomain }) {
 
                 {/* Add to Cart */}
                 <button
+                  disabled={!isOpen}
                   onClick={() => {
                     addToCart(
                       selectedItem,
@@ -701,7 +707,8 @@ export default function RestaurantPage({ subdomain }) {
                       instructions
                     );
                   }}
-                  className="hover:brightness-120 text-white py-2 px-6 rounded-lg font-medium transition-colors" style={{
+                  className={`hover:brightness-120 text-white py-2 px-6 rounded-lg font-medium transition-colors ${!isOpen ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  style={{
                     background: 'var(--theme-primary)',
 
                   }}

--- a/src/app/admin/dashboard/page.js
+++ b/src/app/admin/dashboard/page.js
@@ -34,7 +34,6 @@ function DashboardPage() {
   const [editName, setEditName] = useState('');
   const [editSubdomain, setEditSubdomain] = useState('');
   const [editPhone, setEditPhone] = useState('');
-  const [editOpeningHours, setEditOpeningHours] = useState('');
   const [editExpiresAt, setEditExpiresAt] = useState('');
 
   const [backgroundImageFile, setBackgroundImageFile] = useState(null);
@@ -220,7 +219,6 @@ function DashboardPage() {
       setEditName(restaurant.name);
       setEditSubdomain(restaurant.subdomain);
       setEditPhone(restaurant.phone);
-      setEditOpeningHours(restaurant.openingHours || '');
       setEditInstagramURL(restaurant.instagramURL || '');
       setEditTiktokURL(restaurant.tiktokURL || '');
       setEditFacebookURL(restaurant.facebookURL || '');
@@ -283,7 +281,7 @@ function DashboardPage() {
         name: updatedData.name || editName,
         subdomain: updatedData.subdomain || editSubdomain,
         phone: updatedData.phone || editPhone,
-        openingHours: updatedData.openingHours || editOpeningHours,
+        ...(updatedData.hours && { hours: updatedData.hours }),
         instagramURL: updatedData.instagramURL || editInstagramURL,
         tiktokURL: updatedData.tiktokURL || editTiktokURL,
         facebookURL: updatedData.facebookURL || editFacebookURL,
@@ -775,7 +773,6 @@ function DashboardPage() {
                       name: setEditName,
                       subdomain: setEditSubdomain,
                       phone: setEditPhone,
-                      openingHours: setEditOpeningHours,
                       expiresAt: setEditExpiresAt,
                       username: setEditUsername,
                       password: setEditPassword,
@@ -795,7 +792,6 @@ function DashboardPage() {
                     setAccentColor={setAccentColor}
                     editUsername={editUsername}
                     editPassword={editPassword}
-                    editOpeningHours={editOpeningHours}
                     editInstagramURL={editInstagramURL}
                     editTiktokURL={editTiktokURL}
                     editFacebookURL={editFacebookURL}

--- a/src/components/RestaurantCard.js
+++ b/src/components/RestaurantCard.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import React, { useState, useEffect, useRef } from 'react';
 import { SketchPicker } from 'react-color';
 import BranchManager from '@/components/BranchManager';
+import { daysOfWeek } from '@/utils/openingHours';
 export default function RestaurantCard({
   restaurant,
   branches,
@@ -11,7 +12,6 @@ export default function RestaurantCard({
   editName,
   editSubdomain,
   editPhone,
-  editOpeningHours,
   editExpiresAt,
   onToggleBranches,
   editUsername,
@@ -34,6 +34,24 @@ export default function RestaurantCard({
   const [previewBackgroundImage, setPreviewBackgroundImage] = useState(null);
   const [editLogoFile, setEditLogoFile] = useState(null);
   const [previewLogo, setPreviewLogo] = useState(null);
+  const defaultHours = daysOfWeek.reduce((acc, d) => ({
+    ...acc,
+    [d]: { open: '', close: '' }
+  }), {});
+  const [hours, setHours] = useState(restaurant.hours || defaultHours);
+
+  useEffect(() => {
+    if (showEdit) {
+      setHours(restaurant.hours || defaultHours);
+    }
+  }, [showEdit, restaurant.hours, defaultHours]);
+
+  const handleHoursChange = (day, field, value) => {
+    setHours(prev => ({
+      ...prev,
+      [day]: { ...prev[day], [field]: value }
+    }));
+  };
   const showEdit = editMode === restaurant.id;
   const showBranches = openBranchId === restaurant.id;
   // Set initial expiration date when entering edit mode
@@ -50,7 +68,7 @@ export default function RestaurantCard({
       ...(editName && { name: editName }),
       ...(editSubdomain && { subdomain: editSubdomain }),
       ...(editPhone && { phone: editPhone }),
-      ...(editOpeningHours && { openingHours: editOpeningHours }),
+      hours,
       ...(editExpiresAt && { expiresAt: new Date(editExpiresAt) }),
       ...(editUsername && { username: editUsername }),
       ...(editPassword && { password: editPassword }),
@@ -294,12 +312,26 @@ export default function RestaurantCard({
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700">Opening Hours</label>
-              <input
-                type="text"
-                className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-[#7b68ee] focus:border-[#7b68ee] sm:text-sm text-gray-800 placeholder-gray-400"
-                value={editOpeningHours ?? ''}
-                onChange={(e) => onEditChange.openingHours(e.target.value)}
-              />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {daysOfWeek.map(day => (
+                  <div key={day} className="flex items-center space-x-2">
+                    <span className="w-20 capitalize text-gray-700 text-sm">{day}</span>
+                    <input
+                      type="time"
+                      className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-1 px-2 focus:outline-none focus:ring-[#7b68ee] focus:border-[#7b68ee] sm:text-sm text-gray-800"
+                      value={hours[day]?.open || ''}
+                      onChange={(e) => handleHoursChange(day, 'open', e.target.value)}
+                    />
+                    <span>-</span>
+                    <input
+                      type="time"
+                      className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-1 px-2 focus:outline-none focus:ring-[#7b68ee] focus:border-[#7b68ee] sm:text-sm text-gray-800"
+                      value={hours[day]?.close || ''}
+                      onChange={(e) => handleHoursChange(day, 'close', e.target.value)}
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
             <div>
               <label htmlFor="backgroundImage" className="block text-sm font-medium text-gray-700">

--- a/src/components/RestaurantFooter.js
+++ b/src/components/RestaurantFooter.js
@@ -1,12 +1,24 @@
 'use client';
 import { FaInstagram, FaFacebook, FaTiktok } from 'react-icons/fa';
+import { daysOfWeek, formatTime } from '@/utils/openingHours';
 
-export default function RestaurantFooter({ openingHours, instagramURL, tiktokURL, facebookURL, primaryColor }) {
+export default function RestaurantFooter({ hours, instagramURL, tiktokURL, facebookURL, primaryColor }) {
+  const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
   return (
     <footer className="mt-8 text-white" style={{ background: primaryColor }}>
       <div className="max-w-4xl mx-auto px-4 py-6 flex flex-col items-center space-y-3">
-        {openingHours && (
-          <p className="text-sm">Opening Hours: {openingHours}</p>
+        {hours && (
+          <div className="text-sm text-center space-y-1">
+            {daysOfWeek.map(day => {
+              const info = hours[day] || {};
+              const label = !info.open || !info.close || info.open === info.close
+                ? 'Closed'
+                : `${formatTime(info.open)} - ${formatTime(info.close)}`;
+              return (
+                <p key={day}>{capitalize(day)}: {label}</p>
+              );
+            })}
+          </div>
         )}
         <div className="flex space-x-4">
           {instagramURL && (


### PR DESCRIPTION
## Summary
- track hours for each day of the week
- edit hours in admin dashboard `RestaurantCard`
- enforce hours in restaurant page and disable Add to Cart when closed
- show weekly hours in `RestaurantFooter`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bf4a37e708327a583191a7a93e910