### PR TITLE
Fix menu revenue update after order edits

### DIFF
--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -195,9 +195,14 @@ export default function OrderModal({
         e.preventDefault();
         setIsSubmitting(true);
         try {
+            const updatedItems = formData.cart.map(item => ({
+                ...item,
+                finalTotal: calculateItemTotal(item)
+            }));
+
             const orderToSave = {
                 ...formData,
-                items: formData.cart,
+                items: updatedItems,
                 finalTotal: calculateOrderTotal()
             };
             delete orderToSave.cart;


### PR DESCRIPTION
## Summary
- recalc item `finalTotal` when saving edits to an order

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bfad20c1c832795158a15bb0c1b36