### PR TITLE
Add open toggle for restaurants

### DIFF
--- a/src/app/[subdomain]/RestaurantPage.js
+++ b/src/app/[subdomain]/RestaurantPage.js
@@ -42,7 +42,7 @@ export default function RestaurantPage({ subdomain }) {
   const [isSearching, setIsSearching] = useState(false);
   const [showToast, setShowToast] = useState(false);
   const router = useRouter();
-  const isOpen = isRestaurantOpen(restaurant?.hours);
+  const isOpen = restaurant ? (isRestaurantOpen(restaurant.hours) && restaurant.isOpen !== false) : false;
 
   useEffect(() => {
     const fetchData = async () => {
@@ -198,7 +198,7 @@ export default function RestaurantPage({ subdomain }) {
     isComboSelected = false,
     customInstructions = ''
   ) => {
-    if (!isRestaurantOpen(restaurant?.hours)) {
+    if (!isOpen) {
       toast.error("We're currently closed.");
       return;
     }

--- a/src/app/admin/dashboard/page.js
+++ b/src/app/admin/dashboard/page.js
@@ -60,6 +60,7 @@ function DashboardPage() {
         return {
           id: doc.id,
           ...restaurantData,
+            isOpen: restaurantData.isOpen !== false,
           expiresAt: restaurantData.expiresAt?.toDate
             ? restaurantData.expiresAt
             : restaurantData.expiresAt
@@ -152,6 +153,7 @@ function DashboardPage() {
 
         expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
         isActive: true,
+        isOpen: true,
         logoUrl: uploadedLogoUrl,
         backgroundImageUrl: uploadedBgUrl,
         theme: {
@@ -208,6 +210,14 @@ function DashboardPage() {
       fetchRestaurants();
     } catch (err) {
       console.error('Toggle failed:', err);
+    }
+  };
+  const handleToggleOpen = async (id, currentValue) => {
+    try {
+      await updateDoc(doc(db, "restaurants", id), { isOpen: !currentValue });
+      fetchRestaurants();
+    } catch (err) {
+      console.error("Toggle failed:", err);
     }
   };
 
@@ -784,6 +794,7 @@ function DashboardPage() {
                     onToggleActive={handleToggleActive}
 
 
+                    onToggleOpen={handleToggleOpen}
                     primaryColor={primaryColor}
                     setPrimaryColor={setPrimaryColor}
                     backgroundColor={backgroundColor}

--- a/src/components/RestaurantCard.js
+++ b/src/components/RestaurantCard.js
@@ -24,6 +24,7 @@ export default function RestaurantCard({
   onEditChange,
   onUpdate,
   onToggleActive,
+  onToggleOpen,
   primaryColor,
   setPrimaryColor,
   backgroundColor,
@@ -159,6 +160,13 @@ export default function RestaurantCard({
                 {restaurant.isActive ? 'Active' : 'Inactive'}
 
               </span>
+              <span className={`ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${restaurant.isOpen !== false
+                ? 'bg-green-100 text-green-800'
+                : 'bg-red-100 text-red-800'
+                }`}>
+                {restaurant.isOpen !== false ? 'Open' : 'Closed'}
+
+              </span>
 
             </div>
 
@@ -237,6 +245,22 @@ export default function RestaurantCard({
               )}
             </svg>
             {restaurant.isActive ? 'Disable' : 'Enable'}
+          </button>
+          <button
+            onClick={() => onToggleOpen(restaurant.id, restaurant.isOpen !== false)}
+            className={`inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee] ${restaurant.isOpen !== false
+              ? 'bg-red-600 hover:bg-red-700 text-white'
+              : 'bg-green-600 hover:bg-green-700 text-white'
+              }`}
+          >
+            <svg className="-ml-0.5 mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              {restaurant.isOpen !== false ? (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              )}
+            </svg>
+            {restaurant.isOpen !== false ? 'Close' : 'Open'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `isOpen` flag to newly created restaurants and restaurant fetch logic
- allow admins to toggle restaurant open status
- show open/closed state in admin dashboard cards
- respect `isOpen` when checking restaurant availability in customer view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c08cd9e4483278571b4267673aa34