### PR TITLE
Fix add item in order edit

### DIFF
--- a/src/components/OrderModal.js
+++ b/src/components/OrderModal.js
@@ -436,7 +436,7 @@ export default function OrderModal({
                                 </svg>
                                 Order Items
                             </h3>
-                            {mode === 'edit' && formData.cart.length === 0 && (
+                            {mode === 'edit' && (
                                 <button
                                     type="button"
                                     onClick={() => {


### PR DESCRIPTION
## Summary
- allow adding more items when editing an order

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c0c1333248327af1da139168b183c