### PR TITLE
feat: manage menu from restaurant dashboard

### DIFF
--- a/src/app/[subdomain]/admin/dashboard/page.js
+++ b/src/app/[subdomain]/admin/dashboard/page.js
@@ -14,6 +14,7 @@ import MenuItemsDashboard from '@/components/MenuItemsDashboard';
 import RecentOrders from '@/components/RecentOrders';
 import AnalyticsGraph from '@/components/AnalyticsGraph';
 import OpeningHoursDashboard from '@/components/OpeningHoursDashboard';
+import MenuManagement from '@/components/MenuManagement';
 
 export default function DashboardPage() {
     const [restaurantData, setRestaurantData] = useState(null);
@@ -22,6 +23,7 @@ export default function DashboardPage() {
     const [ordersData, setOrdersData] = useState([]);
     const [menuItems, setMenuItems] = useState([]);
     const [indexError, setIndexError] = useState(false);
+    const [branchId, setBranchId] = useState(null);
     const router = useRouter();
 
     useEffect(() => {
@@ -75,10 +77,11 @@ export default function DashboardPage() {
             if (!querySnapshot.empty) {
                 const restaurantDoc = querySnapshot.docs[0];
                 const restaurantId = restaurantDoc.id;
-                const branchId =
+                const branchIdLocal =
                     typeof window !== 'undefined'
                         ? localStorage.getItem('branchId')
                         : null;
+                setBranchId(branchIdLocal);
 
                 setRestaurantData({
                     id: restaurantId,
@@ -88,11 +91,11 @@ export default function DashboardPage() {
 
                 // Try to fetch orders with the composite query
                 try {
-                    const ordersQuery = branchId
+                    const ordersQuery = branchIdLocal
                         ? query(
                               collection(db, 'orders'),
                               where('restaurantId', '==', restaurantId),
-                              where('branchId', '==', branchId),
+                              where('branchId', '==', branchIdLocal),
                               orderBy('createdAt', 'desc')
                           )
                         : query(
@@ -131,11 +134,11 @@ export default function DashboardPage() {
                         setIndexError(true);
                     }
                     // Fallback: fetch without ordering
-                    const fallbackQuery = branchId
+                    const fallbackQuery = branchIdLocal
                         ? query(
                               collection(db, 'orders'),
                               where('restaurantId', '==', restaurantId),
-                              where('branchId', '==', branchId)
+                              where('branchId', '==', branchIdLocal)
                           )
                         : query(
                               collection(db, 'orders'),
@@ -164,20 +167,20 @@ export default function DashboardPage() {
                 }
 
                 // Fetch menu items, preferring branch-level menu when available
-                let menuCollection = branchId
+                let menuCollection = branchIdLocal
                     ? collection(
                           db,
                           'restaurants',
                           restaurantId,
                           'branches',
-                          branchId,
+                          branchIdLocal,
                           'menu'
                       )
                     : collection(db, 'restaurants', restaurantId, 'menu');
 
                 let menuSnapshot = await getDocs(menuCollection);
 
-                if (menuSnapshot.empty && branchId) {
+                if (menuSnapshot.empty && branchIdLocal) {
                     // Fallback to restaurant-wide menu if no branch-specific menu
                     menuCollection = collection(
                         db,
@@ -233,40 +236,46 @@ export default function DashboardPage() {
             {/* Navigation */}
             <nav className="bg-white shadow-sm">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="flex space-x-8">
+                    <div className="flex space-x-8 overflow-x-auto whitespace-nowrap sm:overflow-visible">
                         <button
                             onClick={() => setActiveTab('overview')}
-                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'overview' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'overview' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
                         >
                             Overview
                         </button>
                         <button
                             onClick={() => setActiveTab('orders')}
-                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'orders' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'orders' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
                         >
                             Orders
                         </button>
                         <button
                             onClick={() => setActiveTab('sales')}
-                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'sales' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'sales' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
                         >
                             Sales
                         </button>
                         <button
                             onClick={() => setActiveTab('customers')}
-                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'customers' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'customers' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
                         >
                             Customers
                         </button>
                         <button
                             onClick={() => setActiveTab('menu')}
-                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'menu' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'menu' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
                         >
                             Menu Items Performance
                         </button>
                         <button
+                            onClick={() => setActiveTab('manageMenu')}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'manageMenu' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                        >
+                            Manage Menu
+                        </button>
+                        <button
                             onClick={() => setActiveTab('hours')}
-                            className={`py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'hours' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
+                            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm ${activeTab === 'hours' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
                         >
                             Opening Hours
                         </button>
@@ -334,6 +343,9 @@ export default function DashboardPage() {
 
                 {activeTab === 'menu' && (
                     <MenuItemsDashboard menuItems={menuItems} orders={ordersData} />
+                )}
+                {activeTab === 'manageMenu' && (
+                    <MenuManagement restaurantId={restaurantData.id} branchId={branchId} />
                 )}
                 {activeTab === 'hours' && (
                     <OpeningHoursDashboard

--- a/src/components/MenuManagement.jsx
+++ b/src/components/MenuManagement.jsx
@@ -1,0 +1,433 @@
+'use client';
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  getDocs,
+  addDoc,
+  doc,
+  deleteDoc,
+  updateDoc,
+  query,
+  orderBy
+} from 'firebase/firestore';
+import { db } from '@/firebase/firebaseConfig';
+import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
+import SortableMenuList from '@/components/SortableMenuList';
+import AddItemModal from '@/components/AddItemModal';
+import EditItemModal from '@/components/EditItemModal';
+import { GripVertical } from 'lucide-react';
+
+export default function MenuManagement({ restaurantId, branchId }) {
+  const [categories, setCategories] = useState([]);
+  const [menuItems, setMenuItems] = useState([]);
+  const [newCategory, setNewCategory] = useState('');
+  const [selectedCategoryId, setSelectedCategoryId] = useState('');
+  const [editMode, setEditMode] = useState(null);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const storage = getStorage();
+
+  const [newItem, setNewItem] = useState({
+    name: '', price: '', typeId: '', type: '',
+    description: '', addons: [], remove: [],
+    imageUrl: '', imageFile: null,
+    isCombo: false,
+    comboPrice: '',
+    comboIncludes: ''
+  });
+
+  const [editItem, setEditItem] = useState({
+    name: '', price: '', typeId: '', type: '',
+    description: '', addons: [], remove: [],
+    imageUrl: '', imageFile: null,
+    isCombo: false,
+    comboPrice: '',
+    comboIncludes: ''
+  });
+
+  useEffect(() => {
+    if (!restaurantId) return;
+    fetchCategories();
+    fetchMenuItems();
+  }, [restaurantId, branchId]);
+
+  const categoriesPath = branchId
+    ? ['restaurants', restaurantId, 'branches', branchId, 'categories']
+    : ['restaurants', restaurantId, 'categories'];
+  const menuPath = branchId
+    ? ['restaurants', restaurantId, 'branches', branchId, 'menu']
+    : ['restaurants', restaurantId, 'menu'];
+
+  const fetchCategories = async () => {
+    const snap = await getDocs(collection(db, ...categoriesPath));
+    const data = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    setCategories(data);
+  };
+
+  const fetchMenuItems = async () => {
+    const q = query(collection(db, ...menuPath), orderBy('sortOrder'));
+    const snap = await getDocs(q);
+
+    const data = await Promise.all(
+      snap.docs.map(async (docSnap, index) => {
+        const item = { id: docSnap.id, ...docSnap.data() };
+        item.sortOrder =
+          typeof item.sortOrder === 'number'
+            ? item.sortOrder
+            : parseInt(item.sortOrder, 10) || index;
+
+        const addonsSnap = await getDocs(collection(db, ...menuPath, docSnap.id, 'addons'));
+        item.addons = addonsSnap.docs.map(doc => doc.data());
+        return item;
+      })
+    );
+
+    data.sort((a, b) => a.sortOrder - b.sortOrder);
+    setMenuItems(data);
+  };
+
+  const handleImageUpload = async (file) => {
+    const fileRef = ref(storage, `menu_images/${file.name}-${Date.now()}`);
+    await uploadBytes(fileRef, file);
+    return await getDownloadURL(fileRef);
+  };
+
+  const deleteImageFromStorage = async (url) => {
+    if (!url) return;
+    try {
+      const pathStart = url.indexOf('/o/') + 3;
+      const pathEnd = url.indexOf('?');
+      const fullPath = decodeURIComponent(url.substring(pathStart, pathEnd));
+      const storageRef = ref(storage, fullPath);
+      await deleteObject(storageRef);
+    } catch (err) {
+      console.warn('Failed to delete old image:', err.message);
+    }
+  };
+
+  const addCategory = async () => {
+    if (!newCategory) return;
+    await addDoc(collection(db, ...categoriesPath), { name: newCategory });
+    setNewCategory('');
+    fetchCategories();
+  };
+
+  const addMenuItem = async () => {
+    const { name, price, description, type, typeId, imageFile, addons, remove } = newItem;
+    if (!name || !price || !type || !typeId) return;
+
+    let imageUrl = '';
+    if (imageFile) imageUrl = await handleImageUpload(imageFile);
+
+    const newItemRef = await addDoc(collection(db, ...menuPath), {
+      name,
+      price: parseFloat(price),
+      description,
+      typeId,
+      type,
+      remove: remove || [],
+      imageUrl,
+      isCombo: newItem.isCombo || false,
+      comboPrice: newItem.comboPrice ? parseFloat(newItem.comboPrice) : null,
+      comboIncludes: newItem.comboIncludes || '',
+      sortOrder: menuItems.length
+    });
+
+    for (const addon of addons) {
+      const parsed = typeof addon === 'string' ? { name: addon, price: 0 } : addon;
+      await addDoc(collection(db, ...menuPath, newItemRef.id, 'addons'), parsed);
+    }
+
+    setNewItem({
+      name: '',
+      price: '',
+      typeId: '',
+      type: '',
+      description: '',
+      addons: [],
+      remove: [],
+      imageUrl: '',
+      imageFile: null
+    });
+    setShowAddModal(false);
+    fetchMenuItems();
+  };
+
+  const deleteMenuItem = async (itemId) => {
+    await deleteDoc(doc(db, ...menuPath, itemId));
+    fetchMenuItems();
+  };
+
+  const handleReorder = async (reordered) => {
+    if (selectedCategoryId) {
+      const categoryIndices = menuItems
+        .map((item, idx) => ({ item, idx }))
+        .filter(({ item }) => item.typeId === selectedCategoryId)
+        .map(({ idx }) => idx);
+
+      const updatedMenu = [...menuItems];
+      categoryIndices.forEach((menuIdx, i) => {
+        updatedMenu[menuIdx] = reordered[i];
+      });
+
+      await Promise.all(
+        updatedMenu.map((item, index) => {
+          if (item.sortOrder !== index) {
+            item.sortOrder = index;
+            return updateDoc(doc(db, ...menuPath, item.id), {
+              sortOrder: index
+            });
+          }
+          return null;
+        })
+      );
+
+      setMenuItems(updatedMenu);
+    } else {
+      await Promise.all(
+        reordered.map((item, index) => {
+          if (item.sortOrder !== index) {
+            item.sortOrder = index;
+            return updateDoc(doc(db, ...menuPath, item.id), {
+              sortOrder: index
+            });
+          }
+          return null;
+        })
+      );
+
+      setMenuItems(reordered);
+    }
+  };
+
+  const handleUpdateItem = async (e) => {
+    e.preventDefault();
+    const itemRef = doc(db, ...menuPath, editMode);
+    let imageUrl = editItem.imageUrl;
+    if (editItem.imageFile) {
+      if (imageUrl) await deleteImageFromStorage(imageUrl);
+      imageUrl = await handleImageUpload(editItem.imageFile);
+    }
+
+    await updateDoc(itemRef, {
+      name: editItem.name,
+      price: parseFloat(editItem.price),
+      description: editItem.description,
+      typeId: editItem.typeId,
+      type: editItem.type,
+      remove: editItem.remove || [],
+      imageUrl,
+      isCombo: editItem.isCombo || false,
+      comboPrice: editItem.comboPrice ? parseFloat(editItem.comboPrice) : null,
+      comboIncludes: editItem.comboIncludes || ''
+    });
+
+    const addonsCollectionRef = collection(db, ...menuPath, editMode, 'addons');
+    const existingAddons = await getDocs(addonsCollectionRef);
+    for (const docSnap of existingAddons.docs) {
+      await deleteDoc(docSnap.ref);
+    }
+    for (const addon of editItem.addons) {
+      const parsed = typeof addon === 'string' ? { name: addon, price: 0 } : addon;
+      await addDoc(addonsCollectionRef, parsed);
+    }
+
+    setEditMode(null);
+    fetchMenuItems();
+  };
+
+  const startEdit = (item) => {
+    setEditMode(item.id);
+    setEditItem({
+      name: item.name,
+      price: item.price.toString(),
+      description: item.description,
+      typeId: item.typeId,
+      type: item.type,
+      addons: item.addons || [],
+      remove: item.remove || [],
+      imageUrl: item.imageUrl || '',
+      imageFile: null,
+      isCombo: item.isCombo || false,
+      comboPrice: item.comboPrice || '',
+      comboIncludes: item.comboIncludes || ''
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6">
+        {/* Categories Section */}
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <div className="px-4 py-4 border-b border-gray-200 sm:px-6">
+            <h3 className="text-lg font-medium leading-6 text-gray-900">Categories</h3>
+          </div>
+          <div className="p-4">
+            <div className="flex flex-col md:flex-row gap-2 mb-4">
+              <input
+                type="text"
+                value={newCategory}
+                onChange={(e) => setNewCategory(e.target.value)}
+                className="flex-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#7b68ee] focus:ring-[#7b68ee] sm:text-sm border p-2 text-gray-800 placeholder-gray-400"
+                placeholder="New category name"
+              />
+              <button
+                onClick={addCategory}
+                className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6]"
+              >
+                Add
+              </button>
+            </div>
+
+            <div className="space-y-2">
+              {categories.map(category => (
+                <div key={category.id} className="flex justify-between items-center p-2 bg-gray-50 rounded">
+                  <span className="text-gray-800">{category.name}</span>
+                  <span className="text-sm text-gray-500">
+                    {menuItems.filter(item => item.typeId === category.id).length} items
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Add Menu Item Section */}
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <div className="px-4 py-4 border-b border-gray-200 sm:px-6">
+            <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-2">
+              <h3 className="text-lg font-medium leading-6 text-gray-900">Menu Items</h3>
+
+              <button
+                onClick={() => setShowAddModal(true)}
+                className="inline-flex items-center justify-center px-3 py-1 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6]"
+              >
+                Add Item
+              </button>
+            </div>
+          </div>
+
+          {/* Category Filter */}
+          <div className="p-4 border-b border-gray-200">
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => setSelectedCategoryId('')}
+                className={`px-3 py-1 rounded-full text-xs font-medium ${selectedCategoryId === '' ? 'bg-[#7b68ee] text-white' : 'bg-gray-100 text-gray-800'}`}
+              >
+                All
+              </button>
+              {categories.map(cat => (
+                <button
+                  key={cat.id}
+                  onClick={() => setSelectedCategoryId(cat.id)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium ${selectedCategoryId === cat.id ? 'bg-[#7b68ee] text-white' : 'bg-gray-100 text-gray-800'}`}
+                >
+                  {cat.name}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Menu Items List */}
+          <SortableMenuList
+            items={menuItems.filter(item => selectedCategoryId === '' || item.typeId === selectedCategoryId)}
+            onReorder={handleReorder}
+            renderItem={(item, handleProps) => (
+              <div className="p-4 flex flex-col md:flex-row gap-4">
+                <div
+                  className="flex items-center cursor-grab text-gray-500 sm:self-start touch-none"
+                  {...handleProps}
+                >
+                  <GripVertical size={20} />
+                </div>
+
+                <div className="flex-1 flex flex-col md:flex-row gap-4">
+                  {item.imageUrl && (
+                    <div className="flex-shrink-0">
+                      <img
+                        src={item.imageUrl}
+                        alt={item.name}
+                        className="h-20 w-20 md:h-24 md:w-24 rounded-lg object-cover border border-gray-200"
+                      />
+                    </div>
+                  )}
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2">
+                      <h4 className="text-base sm:text-lg font-semibold text-gray-900">{item.name}</h4>
+                      <span className="text-base sm:text-lg font-medium text-gray-900">${item.price}</span>
+                    </div>
+
+                    {item.isCombo && (
+                      <div className="mt-1">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+                          Combo
+                        </span>
+                        {item.comboPrice && (
+                          <span className="ml-2 text-sm text-gray-600">Combo Price: ${item.comboPrice}</span>
+                        )}
+                      </div>
+                    )}
+
+                    <p className="mt-1 text-sm text-gray-600">{item.description}</p>
+
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                        {categories.find(cat => cat.id === item.typeId)?.name || 'Uncategorized'}
+                      </span>
+
+                      {item.addons?.length > 0 && (
+                        <div className="w-full mt-1 text-sm text-green-700">
+                          <span className="font-medium">Add-ons: </span>
+                          {item.addons.map(a => a.name || a).join(', ')}
+                        </div>
+                      )}
+
+                      {item.remove?.length > 0 && (
+                        <div className="w-full mt-1 text-sm text-purple-700">
+                          <span className="font-medium">Removables: </span>
+                          {item.remove.join(', ')}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex gap-2 md:flex-col md:gap-1 justify-end">
+                  <button
+                    onClick={() => startEdit(item)}
+                    className="inline-flex items-center justify-center px-3 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-[#7b68ee] hover:bg-[#6a58d6] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#7b68ee]"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteMenuItem(item.id)}
+                    className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
+          />
+        </div>
+      </div>
+
+      <AddItemModal
+        open={showAddModal}
+        onClose={() => setShowAddModal(false)}
+        newItem={newItem}
+        setNewItem={setNewItem}
+        categories={categories}
+        onAdd={addMenuItem}
+      />
+      <EditItemModal
+        open={!!editMode}
+        onClose={() => setEditMode(null)}
+        editItem={editItem}
+        setEditItem={setEditItem}
+        categories={categories}
+        onSave={handleUpdateItem}
+      />
+    </div>
+  );
+}

--- a/src/components/SortableMenuList.jsx
+++ b/src/components/SortableMenuList.jsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
-import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
+import { arrayMove, SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
 function SortableItem({ id, render }) {
@@ -21,7 +21,11 @@ function SortableItem({ id, render }) {
 
 export default function SortableMenuList({ items, renderItem, onReorder }) {
   const [ordered, setOrdered] = useState(items);
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 }
+    })
+  );
 
   useEffect(() => {
     setOrdered(items);


### PR DESCRIPTION
## Summary
- add a menu management tab to restaurant dashboards
- introduce MenuManagement component for adding, editing, and sorting menu items
- make dashboard tabs horizontally scrollable on mobile
- improve touch dragging to prevent page scroll when reordering items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892446c79348327915015a122ee162d