### PR TITLE
Add checkout step indicator and modal components

### DIFF
--- a/src/components/CheckoutForm.js
+++ b/src/components/CheckoutForm.js
@@ -10,7 +10,6 @@ export default function CheckoutForm({
   defaultRegion = 'Mount Lebanon'
 }) {
   const [branches, setBranches] = useState([]);
-  const [loadingBranches, setLoadingBranches] = useState(true);
   const [formData, setFormData] = useState({
     fullName: '',
     mobileNumber: '',
@@ -37,8 +36,6 @@ export default function CheckoutForm({
         setBranches(branchesData);
       } catch (error) {
         console.error('Error fetching branches:', error);
-      } finally {
-        setLoadingBranches(false);
       }
     };
 
@@ -94,10 +91,9 @@ export default function CheckoutForm({
 
 
   return (
-    <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-sm">
+    <form onSubmit={handleSubmit} className="space-y-4">
       <h2 className="text-2xl font-bold text-gray-800 mb-6">Address Details</h2>
-      
-      <form onSubmit={handleSubmit}>
+
         <div className="space-y-4">
           {/* Full Name */}
           <div>
@@ -221,7 +217,6 @@ export default function CheckoutForm({
             Next
           </button>
         </div>
-      </form>
-    </div>
+    </form>
   );
 }

--- a/src/components/LocationPicker.js
+++ b/src/components/LocationPicker.js
@@ -34,14 +34,6 @@ export default function LocationPicker({ onBack, onConfirm, initialLocation }) {
     }
   }, []);
 
-  // Lock background scroll when modal is open
-  useEffect(() => {
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, []);
-
   // Get current position once loaded and permission allows
   useEffect(() => {
     if (!isLoaded) return;
@@ -84,16 +76,14 @@ export default function LocationPicker({ onBack, onConfirm, initialLocation }) {
 
   if (!isLoaded || !center) {
     return (
-      <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-sm">
-        <div className="flex justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-500"></div>
-        </div>
+      <div className="flex items-center justify-center flex-1">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-purple-500"></div>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm w-full h-[80vh] max-h-[600px] flex flex-col">
+    <div className="flex flex-col h-full">
       {/* Permission Denied Alert */}
       {showPermissionAlert && (
         <div className="bg-red-50 border-l-4 border-red-500 p-4">

--- a/src/components/PaymentStep.js
+++ b/src/components/PaymentStep.js
@@ -1,0 +1,55 @@
+'use client';
+
+export default function PaymentStep({ cartTotal, orderNote, onNoteChange, onBack, onPlaceOrder }) {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold text-gray-800 mb-6">Payment Method</h2>
+
+      <div className="space-y-4 mb-6">
+        <div className="p-4 border border-gray-300 rounded-md">
+          <h3 className="font-medium text-gray-800 mb-2">Cash on Delivery</h3>
+          <p className="text-sm text-gray-600">Pay when you receive your order</p>
+        </div>
+      </div>
+
+      <div className="border-t border-gray-200 pt-4">
+        <div className="flex justify-between mb-2">
+          <span className="text-gray-600">Subtotal:</span>
+          <span className="text-gray-800">${cartTotal.toFixed(2)}</span>
+        </div>
+        <div className="flex justify-between mb-4 font-bold">
+          <span className="text-gray-800">Total:</span>
+          <span className="text-gray-800">${cartTotal.toFixed(2)}</span>
+        </div>
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Order Note
+          </label>
+          <textarea
+            value={orderNote}
+            onChange={(e) => onNoteChange(e.target.value)}
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--theme-primary)] text-gray-800 placeholder:text-gray-500"
+            placeholder="Any notes for the restaurant?"
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-between mt-8 pt-4 border-t border-gray-200">
+        <button
+          onClick={onBack}
+          className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300 transition-colors"
+        >
+          Previous
+        </button>
+        <button
+          onClick={onPlaceOrder}
+          className="px-4 py-2 text-white rounded-md hover:brightness-110 transition-colors"
+          style={{ background: 'var(--theme-primary)' }}
+        >
+          Place Order
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StepIndicator.js
+++ b/src/components/StepIndicator.js
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+
+const steps = ['checkout', 'location', 'payment'];
+
+export default function StepIndicator({ currentStep }) {
+  const currentIndex = steps.indexOf(currentStep);
+  return (
+    <div className="flex items-center w-full max-w-xs mx-auto">
+      {steps.map((step, index) => (
+        <React.Fragment key={step}>
+          <div
+            className={`w-4 h-4 rounded-full border-2 ${
+              index <= currentIndex
+                ? 'bg-[var(--theme-primary)] border-[var(--theme-primary)]'
+                : 'border-gray-300 bg-white'
+            }`}
+          />
+          {index < steps.length - 1 && (
+            <div
+              className={`flex-1 h-0.5 mx-2 ${
+                index < currentIndex
+                  ? 'bg-[var(--theme-primary)]'
+                  : 'bg-gray-300'
+              }`}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/components/StepModal.js
+++ b/src/components/StepModal.js
@@ -1,0 +1,25 @@
+'use client';
+import { useEffect } from 'react';
+import StepIndicator from './StepIndicator';
+
+export default function StepModal({ currentStep, children, containerClassName = '', bodyClassName = '' }) {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+      <div className={`bg-white rounded-lg shadow-sm w-full max-w-md ${containerClassName}`}>
+        <div className="p-6 pb-0">
+          <StepIndicator currentStep={currentStep} />
+        </div>
+        <div className={`px-6 pb-6 ${bodyClassName}`}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable step indicator and modal wrapper for checkout flow
- refactor location and address forms to fit new modal layout
- extract payment UI into its own component and wire up all checkout steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b26011d48327a8a38e6f7c3b556d